### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/seq_re/__init__.py
+++ b/seq_re/__init__.py
@@ -200,8 +200,8 @@ __license__ = "LGPL-3.0"
 __version__ = "0.2.1"
 
 # global classes and functions
-from seq_re_main import SeqRegex
-from seq_re_bootstrap import bootstrap
+from .seq_re_main import SeqRegex
+from .seq_re_bootstrap import bootstrap
 
 SeqRegex = SeqRegex
 """Wrapper namespace of SeqRegex in `seq_re_main <seq_re_main.html>`_ module."""

--- a/seq_re/seq_re_bootstrap.py
+++ b/seq_re/seq_re_bootstrap.py
@@ -42,7 +42,7 @@ __copyright__ = "Copyright (C) 2017 GE Ning"
 __license__ = "LGPL-3.0"
 __version__ = "1.0"
 
-import seq_re_main
+from . import seq_re_main
 
 
 def _prepare(len_tuple, pattern, trigger_dict_list):

--- a/seq_re/seq_re_main.py
+++ b/seq_re/seq_re_main.py
@@ -350,4 +350,4 @@ class SeqRegex(object):
         :param sequence: A 2-dimensional Sequence (or the sequence of tuples)
         :return: A list of SeqMatchObject Instance
         """
-        return [self.finditer(pattern, sequence)]
+        return list(self.finditer(pattern, sequence))

--- a/seq_re/seq_re_main.py
+++ b/seq_re/seq_re_main.py
@@ -10,6 +10,8 @@ which is scanned by the RE pattern using search() or findall() functions.
 # todo: deal with multi-value elements in the sequence
 # todo: assign an default name uniquely for group
 
+from __future__ import division
+
 __author__ = "GE Ning <https://github.com/gening/seq_re>"
 __copyright__ = "Copyright (C) 2017 GE Ning"
 __license__ = "LGPL-3.0"
@@ -316,14 +318,14 @@ class SeqRegex(object):
             match_object = SeqRegex.SeqMatchObject(self)
             # The entire match (group_index = 0) and Parenthesized subgroups
             for group_index in range(len(match.groups()) + 1):
-                start = match.start(group_index) / self._len_tuple
-                end = match.end(group_index) / self._len_tuple
+                start = match.start(group_index) // self._len_tuple
+                end = match.end(group_index) // self._len_tuple
                 match_object.group_list.append((group_index,
                                                 sequence[start:end], start, end))
             # Named subgroups
             for group_name, group_index in self._regex.groupindex.items():
-                start = match.start(group_index) / self._len_tuple
-                end = match.end(group_index) / self._len_tuple
+                start = match.start(group_index) // self._len_tuple
+                end = match.end(group_index) // self._len_tuple
                 # group_index is needed to sort the named groups in order
                 match_object.named_group_dict[group_name] = (group_index,
                                                              sequence[start:end], start, end)

--- a/seq_re/seq_re_main.py
+++ b/seq_re/seq_re_main.py
@@ -17,7 +17,7 @@ __version__ = "1.2"
 
 import re
 
-import seq_re_parse as sp
+from . import seq_re_parse as sp
 
 # compatible with Python 2 & 3
 try:

--- a/tests/seq_re_test.py
+++ b/tests/seq_re_test.py
@@ -9,7 +9,7 @@ seq_re_main.py
 seq_re_bootstrap.py
 
 """
-from __future__ import print_function
+from __future__ import print_function, division
 
 __author__ = "GE Ning <https://github.com/gening/seq_regex>"
 __copyright__ = "Copyright (C) 2017 GE Ning"
@@ -43,7 +43,7 @@ def print_pattern_info(pattern):
     for i in range(len(pattern)):
         width = char_width(pattern[i])
         if i % 10 == 0:
-            line.append(str(i / 10) if width == 1 else full_width[i / 10])
+            line.append(str(i // 10) if width == 1 else full_width[i // 10])
         else:
             line.append(' ' if width == 1 else full_width[10])
     print(*line)


### PR DESCRIPTION
The absolute import statements were missing the package name, which caused errors when trying to install them. Using relative imports fixes that. `pip install` should work now.

Integer division also caused `TypeError` in Python 3 because the results were used in slices which don't accept `float`. Using the floor division operator results in an `int` and solves the problem.